### PR TITLE
[Bug Fix]使用支持多字节的字符串替换函数

### DIFF
--- a/src/Pinyin/Pinyin.php
+++ b/src/Pinyin/Pinyin.php
@@ -338,10 +338,18 @@ class Pinyin
      * Add delimiter.
      *
      * @param string $string
+     * @param string $delimiter
+     *
+     * @return string
      */
     protected function delimit($string, $delimiter = '')
     {
-        return preg_replace('/\s+/', strval($delimiter), trim($string));
+        $defaultEncoding = mb_regex_encoding();
+        mb_regex_encoding(static::$internalCharset);
+        $string = mb_ereg_replace('\s+', strval($delimiter), trim($string));
+        mb_regex_encoding($defaultEncoding);
+
+        return $string;
     }
 
     /**


### PR DESCRIPTION
在 Mac OS X下，`\xa0`包括在whitespace中，UTF-8编码下`à`也包含了`\xa0`，直接使用单字符的字符串替换函数会使`à`中的`\xa0`被替换，导致乱码。