### PR TITLE
修复一个multibyte字符产生的问题

### DIFF
--- a/src/Pinyin.php
+++ b/src/Pinyin.php
@@ -143,7 +143,7 @@ class Pinyin
         }
 
         return implode($delimiter, array_map(function ($pinyin) {
-            return \is_numeric($pinyin) ? $pinyin : $pinyin[0];
+            return \is_numeric($pinyin) ? $pinyin : mb_substr($pinyin, 0, 1);
         }, $this->convert($string, $option)));
     }
 

--- a/tests/AbstractDictLoaderTestCase.php
+++ b/tests/AbstractDictLoaderTestCase.php
@@ -116,9 +116,10 @@ abstract class AbstractDictLoaderTestCase extends PHPUnit_Framework_TestCase
     }
 
     // test multibyte non-Chinese character
-    public function testSpecialWordsUsingAbbr() {
+    public function testSpecialWordsUsingAbbr()
+    {
         $pinyin = $this->pinyin;
-        $this->assertEquals('Ⅲdfscdzz', $pinyin->abbr('Ⅲ度房室传导阻滞', PINYIN_KEEP_ENGLISH|PINYIN_KEEP_NUMBER));
+        $this->assertEquals('Ⅲdfscdzz', $pinyin->abbr('Ⅲ度房室传导阻滞', PINYIN_KEEP_ENGLISH | PINYIN_KEEP_NUMBER));
     }
 
     // test Polyphone

--- a/tests/AbstractDictLoaderTestCase.php
+++ b/tests/AbstractDictLoaderTestCase.php
@@ -11,10 +11,14 @@
 
 namespace Overtrue\Pinyin\Test;
 
+use Overtrue\Pinyin\Pinyin;
 use PHPUnit_Framework_TestCase;
 
 abstract class AbstractDictLoaderTestCase extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Pinyin
+     */
     protected $pinyin;
 
     public function testConvert()
@@ -109,6 +113,12 @@ abstract class AbstractDictLoaderTestCase extends PHPUnit_Framework_TestCase
         $this->assertEquals('C pán', $pinyin->sentence('C盘', \PINYIN_TONE));
         $this->assertEquals('G diǎn', $pinyin->sentence('G点', \PINYIN_TONE));
         $this->assertEquals('zhōng dù xìng fèi shuǐ zhǒng', $pinyin->sentence('中度性肺水肿', \PINYIN_TONE));
+    }
+
+    // test multibyte non-Chinese character
+    public function testSpecialWordsUsingAbbr() {
+        $pinyin = $this->pinyin;
+        $this->assertEquals('Ⅲdfscdzz', $pinyin->abbr('Ⅲ度房室传导阻滞', PINYIN_KEEP_ENGLISH|PINYIN_KEEP_NUMBER));
     }
 
     // test Polyphone


### PR DESCRIPTION
类似于"Ⅲ"这样的多字节字符在使用abbr方法的时候, 会产生乱码, 原因是在取第一个字母的时候使用了$pinyin[0]