### PR TITLE
fix function name bug

### DIFF
--- a/src/Pinyin.php
+++ b/src/Pinyin.php
@@ -90,6 +90,8 @@ class Pinyin
      */
     public function name($stringName, $option = PINYIN_NAME)
     {
+        $option = $option | PINYIN_NAME;
+
         $pinyin = $this->romanize($stringName, $option);
 
         return $this->splitWords($pinyin, $option);


### PR DESCRIPTION
超哥, name这个方法，依赖默认参数感觉不对，如果用户传递其他的参数而没有携带”PINYIN_NAME“参数，那就失去“名字转换”这个功能了，和function 名称不符