### PR TITLE
modify default dictLoader from 'FileDictLoader' to 'MemoryFileDictLoader'

### DIFF
--- a/src/Pinyin.php
+++ b/src/Pinyin.php
@@ -47,7 +47,7 @@ class Pinyin
      */
     public function __construct($loaderName = null)
     {
-        $this->loader = $loaderName ?: 'Overtrue\\Pinyin\\FileDictLoader';
+        $this->loader = $loaderName ?: 'Overtrue\\Pinyin\\MemoryFileDictLoader';
     }
 
     /**


### PR DESCRIPTION
"fileDictLoader" will do too many IO operate when i calling 'Convert()' in a loop (in fact, fileDictLoader will IO operate every calling ), so i hope MemoryFileDictLoader can be a defalut implement.